### PR TITLE
feat: direct join without invitation (back-end)

### DIFF
--- a/data/schema.graphql
+++ b/data/schema.graphql
@@ -17,6 +17,35 @@ type Query implements Node {
     nodeId: ID!
   ): Node
 
+  """Reads and enables pagination through a set of `Join`."""
+  joins(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """The method to use when ordering `Join`."""
+    orderBy: [JoinsOrderBy!] = [PRIMARY_KEY_ASC]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: JoinCondition
+  ): JoinsConnection
+
   """Reads and enables pagination through a set of `Match`."""
   matches(
     """Only read the first `n` values of the set."""
@@ -74,11 +103,18 @@ type Query implements Node {
     """
     condition: UserCondition
   ): UsersConnection
+  join(id: Int!): Join
   match(id: Int!): Match
   user(id: Int!): User
 
   """Get the current user."""
   currentUser: User
+
+  """Reads a single `Join` using its globally unique `ID`."""
+  joinByNodeId(
+    """The globally unique `ID` to be used in selecting a single `Join`."""
+    nodeId: ID!
+  ): Join
 
   """Reads a single `Match` using its globally unique `ID`."""
   matchByNodeId(
@@ -101,21 +137,49 @@ interface Node {
   nodeId: ID!
 }
 
-"""A connection to a list of `Match` values."""
-type MatchesConnection {
-  """A list of `Match` objects."""
-  nodes: [Match!]!
+"""A connection to a list of `Join` values."""
+type JoinsConnection {
+  """A list of `Join` objects."""
+  nodes: [Join!]!
 
   """
-  A list of edges which contains the `Match` and cursor to aid in pagination.
+  A list of edges which contains the `Join` and cursor to aid in pagination.
   """
-  edges: [MatchesEdge!]!
+  edges: [JoinsEdge!]!
 
   """Information to aid in pagination."""
   pageInfo: PageInfo!
 
-  """The count of *all* `Match` you could get from the connection."""
+  """The count of *all* `Join` you could get from the connection."""
   totalCount: Int!
+}
+
+"""Participant of a single match."""
+type Join implements Node {
+  """
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  """
+  nodeId: ID!
+
+  """Unique id of the join."""
+  id: Int!
+
+  """Match that this join belongs to."""
+  matchId: Int!
+
+  """User who is joining. Either this or `name` is given."""
+  participantId: Int
+
+  """
+  Name of anonymous user who is joining. Either this or `participant` is given.
+  """
+  name: String
+
+  """Reads a single `Match` that is related to this `Join`."""
+  match: Match
+
+  """Reads a single `User` that is related to this `Join`."""
+  participant: User
 }
 
 """A single beach volley match."""
@@ -140,9 +204,6 @@ type Match implements Node {
   """Is the match public or private. Default is private."""
   public: Boolean!
 
-  """List of participant names who have joined the match."""
-  participants: [String]!
-
   """Host and creator of the match."""
   hostId: Int!
 
@@ -157,6 +218,35 @@ type Match implements Node {
 
   """Reads a single `User` that is related to this `Match`."""
   host: User
+
+  """Reads and enables pagination through a set of `Join`."""
+  joins(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """The method to use when ordering `Join`."""
+    orderBy: [JoinsOrderBy!] = [PRIMARY_KEY_ASC]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: JoinCondition
+  ): JoinsConnection!
 }
 
 """A range of `Datetime`."""
@@ -269,10 +359,80 @@ type User implements Node {
     """
     condition: MatchCondition
   ): MatchesConnection!
+
+  """Reads and enables pagination through a set of `Join`."""
+  joinsByParticipantId(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """The method to use when ordering `Join`."""
+    orderBy: [JoinsOrderBy!] = [PRIMARY_KEY_ASC]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: JoinCondition
+  ): JoinsConnection!
+}
+
+"""A connection to a list of `Match` values."""
+type MatchesConnection {
+  """A list of `Match` objects."""
+  nodes: [Match!]!
+
+  """
+  A list of edges which contains the `Match` and cursor to aid in pagination.
+  """
+  edges: [MatchesEdge!]!
+
+  """Information to aid in pagination."""
+  pageInfo: PageInfo!
+
+  """The count of *all* `Match` you could get from the connection."""
+  totalCount: Int!
+}
+
+"""A `Match` edge in the connection."""
+type MatchesEdge {
+  """A cursor for use in pagination."""
+  cursor: Cursor
+
+  """The `Match` at the end of the edge."""
+  node: Match!
 }
 
 """A location in a connection that can be used for resuming pagination."""
 scalar Cursor
+
+"""Information about pagination in a connection."""
+type PageInfo {
+  """When paginating forwards, are there more items?"""
+  hasNextPage: Boolean!
+
+  """When paginating backwards, are there more items?"""
+  hasPreviousPage: Boolean!
+
+  """When paginating backwards, the cursor to continue."""
+  startCursor: Cursor
+
+  """When paginating forwards, the cursor to continue."""
+  endCursor: Cursor
+}
 
 """Methods to use when ordering `Match`."""
 enum MatchesOrderBy {
@@ -296,28 +456,40 @@ input MatchCondition {
   hostId: Int
 }
 
-"""A `Match` edge in the connection."""
-type MatchesEdge {
+"""Methods to use when ordering `Join`."""
+enum JoinsOrderBy {
+  NATURAL
+  ID_ASC
+  ID_DESC
+  MATCH_ID_ASC
+  MATCH_ID_DESC
+  PARTICIPANT_ID_ASC
+  PARTICIPANT_ID_DESC
+  PRIMARY_KEY_ASC
+  PRIMARY_KEY_DESC
+}
+
+"""
+A condition to be used against `Join` object types. All fields are tested for equality and combined with a logical ‘and.’
+"""
+input JoinCondition {
+  """Checks for equality with the object’s `id` field."""
+  id: Int
+
+  """Checks for equality with the object’s `matchId` field."""
+  matchId: Int
+
+  """Checks for equality with the object’s `participantId` field."""
+  participantId: Int
+}
+
+"""A `Join` edge in the connection."""
+type JoinsEdge {
   """A cursor for use in pagination."""
   cursor: Cursor
 
-  """The `Match` at the end of the edge."""
-  node: Match!
-}
-
-"""Information about pagination in a connection."""
-type PageInfo {
-  """When paginating forwards, are there more items?"""
-  hasNextPage: Boolean!
-
-  """When paginating backwards, are there more items?"""
-  hasPreviousPage: Boolean!
-
-  """When paginating backwards, the cursor to continue."""
-  startCursor: Cursor
-
-  """When paginating forwards, the cursor to continue."""
-  endCursor: Cursor
+  """The `Join` at the end of the edge."""
+  node: Join!
 }
 
 """A connection to a list of `User` values."""
@@ -412,6 +584,22 @@ type Mutation {
     input: DeleteMatchInput!
   ): DeleteMatchPayload
 
+  """Join current user to the match."""
+  join(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: JoinInput!
+  ): JoinPayload
+
+  """Join with name to the private match. _Anonymous user only._"""
+  joinAnonymously(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: JoinAnonymouslyInput!
+  ): JoinAnonymouslyPayload
+
   """Create user or update it's details based on JWT."""
   upsertUser(
     """
@@ -472,12 +660,6 @@ input MatchInput {
 
   """Is the match public or private. Default is private."""
   public: Boolean
-
-  """List of participant names who have joined the match."""
-  participants: [String]
-
-  """Host and creator of the match."""
-  hostId: Int
 
   """Is the match men only, women only, or mixed. Default is mixed."""
   matchType: MatchType
@@ -590,8 +772,14 @@ input MatchPatch {
   """Is the match public or private. Default is private."""
   public: Boolean
 
-  """List of participant names who have joined the match."""
-  participants: [String]
+  """Is the match men only, women only, or mixed. Default is mixed."""
+  matchType: MatchType
+
+  """Required player skill level for the match. Default is EASY_HARD."""
+  requiredSkillLevel: SkillLevel
+
+  """Optional description of the match."""
+  description: String
 }
 
 """All input for the `updateMatch` mutation."""
@@ -662,6 +850,81 @@ input DeleteMatchInput {
 
   """Unique id of the match."""
   id: Int!
+}
+
+"""The output of our `join` mutation."""
+type JoinPayload {
+  """
+  The exact same `clientMutationId` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  """
+  clientMutationId: String
+  join: Join
+
+  """
+  Our root query field type. Allows us to run any query from our mutation payload.
+  """
+  query: Query
+
+  """Reads a single `Match` that is related to this `Join`."""
+  match: Match
+
+  """Reads a single `User` that is related to this `Join`."""
+  participant: User
+
+  """An edge for our `Join`. May be used by Relay 1."""
+  joinEdge(
+    """The method to use when ordering `Join`."""
+    orderBy: [JoinsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): JoinsEdge
+}
+
+"""All input for the `join` mutation."""
+input JoinInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+  matchId: Int!
+}
+
+"""The output of our `joinAnonymously` mutation."""
+type JoinAnonymouslyPayload {
+  """
+  The exact same `clientMutationId` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  """
+  clientMutationId: String
+  join: Join
+
+  """
+  Our root query field type. Allows us to run any query from our mutation payload.
+  """
+  query: Query
+
+  """Reads a single `Match` that is related to this `Join`."""
+  match: Match
+
+  """Reads a single `User` that is related to this `Join`."""
+  participant: User
+
+  """An edge for our `Join`. May be used by Relay 1."""
+  joinEdge(
+    """The method to use when ordering `Join`."""
+    orderBy: [JoinsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): JoinsEdge
+}
+
+"""All input for the `joinAnonymously` mutation."""
+input JoinAnonymouslyInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+  matchId: Int!
+  name: String!
 }
 
 """The output of our `upsertUser` mutation."""

--- a/data/schema.sql
+++ b/data/schema.sql
@@ -151,6 +151,126 @@ COMMENT ON FUNCTION beachvolley_public."current_user"() IS 'Get the current user
 
 
 --
+-- Name: join; Type: TABLE; Schema: beachvolley_public; Owner: -
+--
+
+CREATE TABLE beachvolley_public."join" (
+    id integer NOT NULL,
+    match_id integer NOT NULL,
+    participant_id integer,
+    name text,
+    created_at timestamp without time zone DEFAULT now(),
+    updated_at timestamp without time zone DEFAULT now(),
+    CONSTRAINT join_check CHECK ((num_nonnulls(participant_id, name) = 1))
+);
+
+
+--
+-- Name: TABLE "join"; Type: COMMENT; Schema: beachvolley_public; Owner: -
+--
+
+COMMENT ON TABLE beachvolley_public."join" IS 'Participant of a single match.';
+
+
+--
+-- Name: COLUMN "join".id; Type: COMMENT; Schema: beachvolley_public; Owner: -
+--
+
+COMMENT ON COLUMN beachvolley_public."join".id IS 'Unique id of the join.';
+
+
+--
+-- Name: COLUMN "join".match_id; Type: COMMENT; Schema: beachvolley_public; Owner: -
+--
+
+COMMENT ON COLUMN beachvolley_public."join".match_id IS 'Match that this join belongs to.';
+
+
+--
+-- Name: COLUMN "join".participant_id; Type: COMMENT; Schema: beachvolley_public; Owner: -
+--
+
+COMMENT ON COLUMN beachvolley_public."join".participant_id IS 'User who is joining. Either this or `name` is given.';
+
+
+--
+-- Name: COLUMN "join".name; Type: COMMENT; Schema: beachvolley_public; Owner: -
+--
+
+COMMENT ON COLUMN beachvolley_public."join".name IS 'Name of anonymous user who is joining. Either this or `participant` is given.';
+
+
+--
+-- Name: COLUMN "join".created_at; Type: COMMENT; Schema: beachvolley_public; Owner: -
+--
+
+COMMENT ON COLUMN beachvolley_public."join".created_at IS '@omit all,create,delete,many,read,update';
+
+
+--
+-- Name: COLUMN "join".updated_at; Type: COMMENT; Schema: beachvolley_public; Owner: -
+--
+
+COMMENT ON COLUMN beachvolley_public."join".updated_at IS '@omit all,create,delete,many,read,update';
+
+
+--
+-- Name: join(integer); Type: FUNCTION; Schema: beachvolley_public; Owner: -
+--
+
+CREATE FUNCTION beachvolley_public."join"(match_id integer) RETURNS beachvolley_public."join"
+    LANGUAGE plpgsql STRICT SECURITY DEFINER
+    AS $$
+declare
+  new_join beachvolley_public.join;
+begin
+  insert into beachvolley_public.join (match_id, participant_id)
+    values (match_id, beachvolley_private.current_user_id())
+    returning * into new_join;
+
+  return new_join;
+end;
+$$;
+
+
+--
+-- Name: FUNCTION "join"(match_id integer); Type: COMMENT; Schema: beachvolley_public; Owner: -
+--
+
+COMMENT ON FUNCTION beachvolley_public."join"(match_id integer) IS 'Join current user to the match.';
+
+
+--
+-- Name: join_anonymously(integer, text); Type: FUNCTION; Schema: beachvolley_public; Owner: -
+--
+
+CREATE FUNCTION beachvolley_public.join_anonymously(match_id integer, name text) RETURNS beachvolley_public."join"
+    LANGUAGE plpgsql STRICT SECURITY DEFINER
+    AS $$
+declare
+  new_join beachvolley_public.join;
+begin
+  if exists (select 1 from beachvolley_public.match where id = match_id and public = false) then
+    insert into beachvolley_public.join (match_id, name)
+      values (match_id, name)
+      returning * into new_join;
+
+    return new_join;
+  end if;
+
+  return null;
+end;
+$$;
+
+
+--
+-- Name: FUNCTION join_anonymously(match_id integer, name text); Type: COMMENT; Schema: beachvolley_public; Owner: -
+--
+
+COMMENT ON FUNCTION beachvolley_public.join_anonymously(match_id integer, name text) IS 'Join with name to the private match. _Anonymous user only._';
+
+
+--
 -- Name: upsert_user(); Type: FUNCTION; Schema: beachvolley_public; Owner: -
 --
 
@@ -230,6 +350,20 @@ ALTER TABLE beachvolley_public.invitation ALTER COLUMN id ADD GENERATED ALWAYS A
 
 
 --
+-- Name: join_id_seq; Type: SEQUENCE; Schema: beachvolley_public; Owner: -
+--
+
+ALTER TABLE beachvolley_public."join" ALTER COLUMN id ADD GENERATED ALWAYS AS IDENTITY (
+    SEQUENCE NAME beachvolley_public.join_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1
+);
+
+
+--
 -- Name: match; Type: TABLE; Schema: beachvolley_public; Owner: -
 --
 
@@ -241,12 +375,10 @@ CREATE TABLE beachvolley_public.match (
     "time" tstzrange,
     player_limit int4range,
     public boolean DEFAULT false NOT NULL,
-    participants text[] DEFAULT ARRAY[]::text[] NOT NULL,
     host_id integer DEFAULT beachvolley_private.current_user_id() NOT NULL,
     match_type text DEFAULT 'mixed'::text NOT NULL,
     required_skill_level text DEFAULT 'easy-hard'::text NOT NULL,
-    description text,
-    CONSTRAINT match_participants_check CHECK ((array_position(participants, NULL::text) IS NULL))
+    description text
 );
 
 
@@ -307,17 +439,11 @@ COMMENT ON COLUMN beachvolley_public.match.public IS 'Is the match public or pri
 
 
 --
--- Name: COLUMN match.participants; Type: COMMENT; Schema: beachvolley_public; Owner: -
---
-
-COMMENT ON COLUMN beachvolley_public.match.participants IS 'List of participant names who have joined the match.';
-
-
---
 -- Name: COLUMN match.host_id; Type: COMMENT; Schema: beachvolley_public; Owner: -
 --
 
-COMMENT ON COLUMN beachvolley_public.match.host_id IS 'Host and creator of the match.';
+COMMENT ON COLUMN beachvolley_public.match.host_id IS '@omit create
+Host and creator of the match.';
 
 
 --
@@ -438,6 +564,14 @@ ALTER TABLE ONLY beachvolley_public.invitation
 
 
 --
+-- Name: join join_pkey; Type: CONSTRAINT; Schema: beachvolley_public; Owner: -
+--
+
+ALTER TABLE ONLY beachvolley_public."join"
+    ADD CONSTRAINT join_pkey PRIMARY KEY (id);
+
+
+--
 -- Name: match match_pkey; Type: CONSTRAINT; Schema: beachvolley_public; Owner: -
 --
 
@@ -485,6 +619,34 @@ CREATE INDEX invitation_match_id_idx ON beachvolley_public.invitation USING btre
 
 
 --
+-- Name: join_match_id_idx; Type: INDEX; Schema: beachvolley_public; Owner: -
+--
+
+CREATE INDEX join_match_id_idx ON beachvolley_public."join" USING btree (match_id);
+
+
+--
+-- Name: join_match_id_name_idx; Type: INDEX; Schema: beachvolley_public; Owner: -
+--
+
+CREATE UNIQUE INDEX join_match_id_name_idx ON beachvolley_public."join" USING btree (match_id, name) WHERE (name IS NOT NULL);
+
+
+--
+-- Name: join_match_id_participant_id_idx; Type: INDEX; Schema: beachvolley_public; Owner: -
+--
+
+CREATE UNIQUE INDEX join_match_id_participant_id_idx ON beachvolley_public."join" USING btree (match_id, participant_id) WHERE (participant_id IS NOT NULL);
+
+
+--
+-- Name: join_participant_id_idx; Type: INDEX; Schema: beachvolley_public; Owner: -
+--
+
+CREATE INDEX join_participant_id_idx ON beachvolley_public."join" USING btree (participant_id);
+
+
+--
 -- Name: match_host_id_idx; Type: INDEX; Schema: beachvolley_public; Owner: -
 --
 
@@ -496,6 +658,13 @@ CREATE INDEX match_host_id_idx ON beachvolley_public.match USING btree (host_id)
 --
 
 CREATE TRIGGER user_private_updated_at BEFORE UPDATE ON beachvolley_private."user" FOR EACH ROW EXECUTE FUNCTION beachvolley_private.set_updated_at();
+
+
+--
+-- Name: join join_updated_at; Type: TRIGGER; Schema: beachvolley_public; Owner: -
+--
+
+CREATE TRIGGER join_updated_at BEFORE UPDATE ON beachvolley_public."join" FOR EACH ROW EXECUTE FUNCTION beachvolley_private.set_updated_at();
 
 
 --
@@ -526,6 +695,22 @@ ALTER TABLE ONLY beachvolley_private."user"
 
 ALTER TABLE ONLY beachvolley_public.invitation
     ADD CONSTRAINT invitation_match_id_fkey FOREIGN KEY (match_id) REFERENCES beachvolley_public.match(id) ON DELETE CASCADE;
+
+
+--
+-- Name: join join_match_id_fkey; Type: FK CONSTRAINT; Schema: beachvolley_public; Owner: -
+--
+
+ALTER TABLE ONLY beachvolley_public."join"
+    ADD CONSTRAINT join_match_id_fkey FOREIGN KEY (match_id) REFERENCES beachvolley_public.match(id) ON DELETE CASCADE;
+
+
+--
+-- Name: join join_participant_id_fkey; Type: FK CONSTRAINT; Schema: beachvolley_public; Owner: -
+--
+
+ALTER TABLE ONLY beachvolley_public."join"
+    ADD CONSTRAINT join_participant_id_fkey FOREIGN KEY (participant_id) REFERENCES beachvolley_public."user"(id) ON DELETE SET NULL;
 
 
 --
@@ -595,6 +780,30 @@ GRANT ALL ON FUNCTION beachvolley_public."current_user"() TO beachvolley_graphil
 
 
 --
+-- Name: TABLE "join"; Type: ACL; Schema: beachvolley_public; Owner: -
+--
+
+GRANT SELECT ON TABLE beachvolley_public."join" TO beachvolley_graphile_anonymous;
+GRANT SELECT ON TABLE beachvolley_public."join" TO beachvolley_graphile_authenticated;
+
+
+--
+-- Name: FUNCTION "join"(match_id integer); Type: ACL; Schema: beachvolley_public; Owner: -
+--
+
+REVOKE ALL ON FUNCTION beachvolley_public."join"(match_id integer) FROM PUBLIC;
+GRANT ALL ON FUNCTION beachvolley_public."join"(match_id integer) TO beachvolley_graphile_authenticated;
+
+
+--
+-- Name: FUNCTION join_anonymously(match_id integer, name text); Type: ACL; Schema: beachvolley_public; Owner: -
+--
+
+REVOKE ALL ON FUNCTION beachvolley_public.join_anonymously(match_id integer, name text) FROM PUBLIC;
+GRANT ALL ON FUNCTION beachvolley_public.join_anonymously(match_id integer, name text) TO beachvolley_graphile_anonymous;
+
+
+--
 -- Name: FUNCTION upsert_user(); Type: ACL; Schema: beachvolley_public; Owner: -
 --
 
@@ -640,10 +849,24 @@ GRANT INSERT(public),UPDATE(public) ON TABLE beachvolley_public.match TO beachvo
 
 
 --
--- Name: COLUMN match.participants; Type: ACL; Schema: beachvolley_public; Owner: -
+-- Name: COLUMN match.match_type; Type: ACL; Schema: beachvolley_public; Owner: -
 --
 
-GRANT INSERT(participants),UPDATE(participants) ON TABLE beachvolley_public.match TO beachvolley_graphile_authenticated;
+GRANT UPDATE(match_type) ON TABLE beachvolley_public.match TO beachvolley_graphile_authenticated;
+
+
+--
+-- Name: COLUMN match.required_skill_level; Type: ACL; Schema: beachvolley_public; Owner: -
+--
+
+GRANT UPDATE(required_skill_level) ON TABLE beachvolley_public.match TO beachvolley_graphile_authenticated;
+
+
+--
+-- Name: COLUMN match.description; Type: ACL; Schema: beachvolley_public; Owner: -
+--
+
+GRANT UPDATE(description) ON TABLE beachvolley_public.match TO beachvolley_graphile_authenticated;
 
 
 --

--- a/migrations/committed/000014.sql
+++ b/migrations/committed/000014.sql
@@ -1,0 +1,47 @@
+--! Previous: sha1:bae7adc100886b6bc1313893cfea494265d91a20
+--! Hash: sha1:5498a9c262993df4299d8c0c3b418ed8198428c3
+
+-- Enter migration here
+
+-- revert changes for idempotency
+drop table if exists beachvolley_public.join;
+
+-- add join table
+create table beachvolley_public.join (
+  id integer primary key generated always as identity,
+  match_id integer not null references beachvolley_public.match(id) on delete cascade,
+  participant_id integer references beachvolley_public.user(id) on delete set null,
+  name text,
+  created_at timestamp default now(),
+  updated_at timestamp default now(),
+  check (num_nonnulls(participant_id, name) = 1) -- check that either participant_id or name is given
+);
+
+create trigger join_updated_at before update
+  on beachvolley_public.join
+  for each row
+  execute procedure beachvolley_private.set_updated_at();
+
+create index on beachvolley_public.join (match_id);
+create index on beachvolley_public.join (participant_id);
+create unique index on beachvolley_public.join (match_id, participant_id) where (participant_id is not null);
+create unique index on beachvolley_public.join (match_id, name) where (name is not null);
+
+comment on table beachvolley_public.join is 'Participant of a single match.';
+comment on column beachvolley_public.join.id is 'Unique id of the join.';
+comment on column beachvolley_public.join.match_id is 'Match that this join belongs to.';
+comment on column beachvolley_public.join.participant_id is 'User who is joining. Either this or `name` is given.';
+comment on column beachvolley_public.join.name is 'Name of anonymous user who is joining. Either this or `participant` is given.';
+comment on column beachvolley_public.join.created_at is '@omit all,create,delete,many,read,update';
+comment on column beachvolley_public.join.updated_at is '@omit all,create,delete,many,read,update';
+
+grant select on table beachvolley_public.join to beachvolley_graphile_anonymous, beachvolley_graphile_authenticated;
+
+-- drop participants field from match as join is replacing it
+alter table beachvolley_public.match drop column if exists participants;
+
+-- remove host from createMatch mutation as it is not allowed there anyways
+comment on column beachvolley_public.match.host_id is E'@omit create\nHost and creator of the match.';
+
+-- allow updating match type, required skill level and description of match
+grant update(match_type, required_skill_level, description) on table beachvolley_public.match to beachvolley_graphile_authenticated;

--- a/migrations/committed/000015.sql
+++ b/migrations/committed/000015.sql
@@ -1,0 +1,38 @@
+--! Previous: sha1:5498a9c262993df4299d8c0c3b418ed8198428c3
+--! Hash: sha1:bf496e7f20b5e7e414f82fe456f552a9fbf89809
+
+-- Enter migration here
+
+drop function if exists beachvolley_public.join_anonymously;
+create function beachvolley_public.join_anonymously(match_id integer, name text) returns beachvolley_public.join as $$
+declare
+  new_join beachvolley_public.join;
+begin
+  if exists (select 1 from beachvolley_public.match where id = match_id and public = false) then
+    insert into beachvolley_public.join (match_id, name)
+      values (match_id, name)
+      returning * into new_join;
+
+    return new_join;
+  end if;
+
+  return null;
+end;
+$$ language plpgsql strict security definer;
+grant execute on function beachvolley_public.join_anonymously to beachvolley_graphile_anonymous;
+comment on function beachvolley_public.join_anonymously is 'Join with name to the private match. _Anonymous user only._';
+
+drop function if exists beachvolley_public.join;
+create function beachvolley_public.join(match_id integer) returns beachvolley_public.join as $$
+declare
+  new_join beachvolley_public.join;
+begin
+  insert into beachvolley_public.join (match_id, participant_id)
+    values (match_id, beachvolley_private.current_user_id())
+    returning * into new_join;
+
+  return new_join;
+end;
+$$ language plpgsql strict security definer;
+grant execute on function beachvolley_public.join to beachvolley_graphile_authenticated;
+comment on function beachvolley_public.join is 'Join current user to the match.';


### PR DESCRIPTION
- anonymous user can join (with given name) to private match.
- authenticated user can join to any match.

Changes to GraphQL schema:

New in types:
```graphql
type Join {
  id: Int!
  match: Match
  name: String # this is used when joined anonymously
  participant: User # this is used when joined as user
}

type Match {
  # ...
  joins(...): JoinsConnection!
}

type User {
  # ...
  joinsByParticipantId(...): JoinsConnection!
}
```

New in queries:
```graphql
joins(...): JoinsConnection
join(id: Int!): Join
```

New in mutations:
```graphql
join(input: { matchId: Int! }!): Join # use this when authenticated
joinAnonymously(input: { matchId: Int!, name: String! }!): Join # use this when anonymous
```